### PR TITLE
Update katello_sync_plan example

### DIFF
--- a/modules/katello_sync_plan.py
+++ b/modules/katello_sync_plan.py
@@ -98,7 +98,7 @@ EXAMPLES = '''
     enabled: false
     sync_date: "2017/01/01 00:00:00 +0000"
     products:
-      - name: 'Red Hat Enterprise Linux Server'
+      - 'Red Hat Enterprise Linux Server'
 '''
 
 RETURN = ''' # '''


### PR DESCRIPTION
Update the katelllo_sync_plan example to a useable format.  The product parameter requires a list, but each element in the list shoudl be a string object, not a dictionary.